### PR TITLE
Fix Reduce Operator

### DIFF
--- a/addons/funcy/ListOperators.gd
+++ b/addons/funcy/ListOperators.gd
@@ -95,8 +95,8 @@ class Reduce:
 			assert(not data.empty())
 			return data[0]
 		var result = op.eval2(data[0], data[1])
-		for i in range(2, data.size()-1):
-			result = op.eval2(result, data[i+1])
+		for i in range(2, data.size()):
+			result = op.eval2(result, data[i])
 		return result
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Hello, it's nice library!

I found a bug and fixed it.
The second item of list seem to be skipped on reduce operation.
(Godot's built-in range is tail exclusive)

```
const F := Funcy

func _run():
  var list = range(1, 11)
  var sum = F.reduce(F.expr("_x + _y"), list)
  print(list)
  print(sum)

# [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
# 52
```
Above `sum` should be 55, but shows (55 -3) = 52?